### PR TITLE
Raise exceptions for known API error states

### DIFF
--- a/box_view.gemspec
+++ b/box_view.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/reillyforshaw/box_view"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '>= 1.9'
+
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
@@ -20,4 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 end

--- a/lib/box_view.rb
+++ b/lib/box_view.rb
@@ -4,6 +4,8 @@ require "net/http"
 require "json"
 
 module BoxView
+  class Error < StandardError; end
+
   {
     Session: 'session',
     Http:    'http'

--- a/lib/box_view/models/base.rb
+++ b/lib/box_view/models/base.rb
@@ -1,9 +1,9 @@
 module BoxView
   module Models
 
-    class ReadOnlyAttribute < Exception; end
-    class ResourceNotSaved < Exception; end
-    
+    class ReadOnlyAttribute < BoxView::Error; end
+    class ResourceNotSaved < BoxView::Error; end
+
     class Base
 
       require 'time'

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -5,10 +5,65 @@ describe BoxView::Http do
 
   describe "#parse_response" do
     context "when given ill-formed JSON" do
-      let(:response) { response = double("Net::HTTPResponse", body: "foo") }
-      
+      let(:response) { double("Net::HTTPResponse", body: "foo") }
+
       it "should return nil" do
         expect(http.parse_response(response)).to be_nil
+      end
+    end
+  end
+
+  describe '#check_for_error' do
+    let(:response) { }
+    subject { http.check_for_error(response) }
+
+    context 'given a 202 response' do
+      let(:response) { Net::HTTPAccepted.new('1.1', '202', 'ACCEPTED') }
+
+      context 'that does not have a Retry-After header' do
+        it 'should not raise an error' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'that does have a Retry-After header' do
+        let(:response) { super().tap { |r| r['Retry-After'] = '10' } }
+        it 'should raise a BoxView::Http:RetryNeeded' do
+          expect { subject }.to raise_error(BoxView::Http::RetryNeededError) do |error|
+            error.retry_after.should == '10'
+          end
+        end
+      end
+    end
+
+    context 'given a 400 response' do
+      let(:body) { }
+      let(:response) do
+        Net::HTTPBadRequest.new('1.1', '400', 'BAD REQUEST').tap do |r|
+          r.stub(:body).and_return(body)
+        end
+      end
+
+      context 'without a parseable error message' do
+        let(:body) { 'NOT JSON' }
+
+        it 'should raise a BoxView::Http:BadRequest' do
+          expect { subject }.to raise_error(BoxView::Http::BadRequestError)
+        end
+      end
+
+      context 'with a parseable error message' do
+        let(:body) do
+          '{"message": "Bad request",
+            "type": "error",
+            "details": [{"field": "height",
+                         "message": "Ensure this value is less than or equal to 768."}],
+            "request_id": "999605a17b974850baaccbe2ae479c75"}'
+        end
+
+        it 'should raise a BoxView::Http:BadRequest with a message indicating the problem' do
+          expect { subject }.to raise_error(BoxView::Http::BadRequestError, /height/)
+        end
       end
     end
   end


### PR DESCRIPTION
Namely, for HTTP response code 202 responses (with a Retry-After header set) and 400 Bad Request responses. Both as per the [View API docs](https://developers.box.com/view/).

Otherwise these responses where raising unrelated errors (e.g. a 202 for a `DocumentSession` that ended up in something along the lines of a `nil.each` call) or unexpected values (e.g. a JSON body with error messages for a requested `Document#thumbnail` that was too large). 
