### PR TITLE
Handle API request throttling (HTTP status code 429) by raising error

### DIFF
--- a/lib/box_view/http.rb
+++ b/lib/box_view/http.rb
@@ -70,19 +70,19 @@ module BoxView
     end
 
     def check_for_error(res)
-      case res
-      when Net::HTTPAccepted
+      case res.code.to_s
+      when '202' # Accepted
         if res['Retry-After']
           raise BoxView::Http::RetryNeededError.new('Retry Needed', res['Retry-After'])
         end
-      when Net::HTTPBadRequest
+      when '400' # Bad Request
         msg = 'Bad Request'
         if err_dets = error_details(res)
           msg += " (#{err_dets})"
         end
 
         raise BoxView::Http::BadRequestError.new(msg)
-      when Net::HTTPTooManyRequests
+      when '429' # Too Many Requests
         raise BoxView::Http::RequestThrottledError.new('Request Throttled', res['Retry-After'])
       end
     end

--- a/lib/box_view/http.rb
+++ b/lib/box_view/http.rb
@@ -14,6 +14,7 @@ module BoxView
         super(msg)
       end
     end
+    class RequestThrottledError < BoxView::Http::RetryNeededError; end
 
     def base_uri(path, params = {})
       uri = URI.parse("https://view-api.box.com")
@@ -81,6 +82,8 @@ module BoxView
         end
 
         raise BoxView::Http::BadRequestError.new(msg)
+      when Net::HTTPTooManyRequests
+        raise BoxView::Http::RequestThrottledError.new('Request Throttled', res['Retry-After'])
       end
     end
 

--- a/lib/box_view/models/base.rb
+++ b/lib/box_view/models/base.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module BoxView
   module Models
 

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -73,7 +73,7 @@ describe BoxView::Http do
           "request_id": "5b296c69f9f94c0eace43a5912fcbb41"}'
       end
       let(:response) do
-        Net::HTTPTooManyRequests.new('1.1', '429', 'TOO MANY REQUESTS').tap do |r|
+        Net::HTTPClientError.new('1.1', '429', 'TOO MANY REQUESTS').tap do |r|
           r['Retry-After'] == '2'
           r.stub(:body).and_return(body)
         end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -66,5 +66,24 @@ describe BoxView::Http do
         end
       end
     end
+
+    context 'given a 429 response' do
+      let(:body) do
+        '{"message": "Request was throttled. Try again in 2 seconds", "type": "error",
+          "request_id": "5b296c69f9f94c0eace43a5912fcbb41"}'
+      end
+      let(:response) do
+        Net::HTTPTooManyRequests.new('1.1', '429', 'TOO MANY REQUESTS').tap do |r|
+          r['Retry-After'] == '2'
+          r.stub(:body).and_return(body)
+        end
+      end
+
+      it 'should raise a BoxView::Http:BadRequest with a message indicating the problem' do
+        expect { subject }.to raise_error(BoxView::Http::RequestThrottledError) do |error|
+          error.retry_after.should == '2'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I found another known API error response (the hard way): Box will throttle API requests if they get to many. This commit checks for that response and raises an error accordingly.
